### PR TITLE
Quell warning for benign nonexhaustive match

### DIFF
--- a/src/parse.sml
+++ b/src/parse.sml
@@ -97,7 +97,7 @@ struct
 		  [] => ""
 		| [x] => "Expected " ^ fmt x ^ ". "
 		| x :: xs  => "Expected " ^ fmt x ^ exps xs
-	  fun msg msgs = (String.concatWith ". " o List.map (fn Message m => m))
+	  fun msg msgs = (String.concatWith ". " o List.map (fn Message m => m | _ => raise Match))
 			     (List.filter (fn Message _ => true | _ => false) msgs)
       in "Parse error at " ^ Pos.toString p ^ ": " ^
 	 unex msgs ^ exp msgs ^ msg msgs ^ "\n"


### PR DESCRIPTION
The nonexhaustive pattern match is benign here, because it is guaranteed
to succeed by means of a filter. By adding the explicit `_ => raise
Match` clause, we can prevent the warning that ML compilers will report
every time parcom is built.
